### PR TITLE
Logger to obj

### DIFF
--- a/lib/Test/Mini/Runner.pm
+++ b/lib/Test/Mini/Runner.pm
@@ -80,6 +80,19 @@ sub filter {
 # @return Logger instance.
 sub logger {
     my $self = shift;
+
+    unless (ref($self->{logger})) { #logger is still a string, make an obj
+        my $logger = $self->{logger};
+        try {
+            eval "require $logger;" or die $@;
+        }
+        catch {
+            $logger = qq{Test::Mini::Logger::$logger};
+            eval "require $logger;" or die $@;
+        };
+        $self->{logger} = $logger->new(verbose => $self->verbose);
+    }
+
     return $self->{logger};
 }
 
@@ -104,16 +117,6 @@ sub exit_code {
 # @return The result of the {#run_test_suite} call.
 sub run {
     my ($self) = @_;
-    my $logger = $self->logger;
-    try {
-        eval "require $logger;" or die $@;
-    }
-    catch {
-        eval "require Test::Mini::Logger::$logger;" or die $@;
-    };
-
-    $logger = $logger->new(verbose => $self->verbose);
-    $self->{logger} = $logger;
 
     return $self->run_test_suite(filter => $self->filter, seed => $self->seed);
 }

--- a/t/logger_auto_object.t
+++ b/t/logger_auto_object.t
@@ -1,0 +1,22 @@
+#!/usr/bin/perl 
+use strict;
+use warnings;
+use Test::More qw{no_plan};
+
+BEGIN {
+
+   use_ok('Test::Mini::Runner');
+   can_ok('Test::Mini::Runner', qw{
+      logger
+   });
+
+};
+#-----------------------------------------------------------------
+ok my $r  = Test::Mini::Runner->new;
+isa_ok  $r, 'Test::Mini::Runner';
+
+is $r->{logger}, 'Test::Mini::Logger::TAP';
+isa_ok $r->logger, 'Test::Mini::Logger::TAP';
+ok $r->{logger} = 'TAP';
+isa_ok $r->logger, 'Test::Mini::Logger::TAP';
+


### PR DESCRIPTION
Sorry that I didn't make this a proper assert based test, I might get to that later but the issue was that I was running in to an error when I called runner->run_test_suite on it's own. The issue is that runner->run converts logger the class name to logger the object, but when you don't use 'run' you start seeing warnings about not being able to use a string as an object. 

I'm not exactly sure if this is the best method as every call to runner->logger will check the type for $self->{logger} and that seems needless but it does allow for things to 'do the right thing' for all the existing code with out having to add some check to all the run\* methods, also if there ever is a need to change loggers mid stream (though doubt thats a useful case to account for?). 

Either way this solved my case but it's not the most 'normal' case so this could just be needless and I should be doing the check on my side.
