### PR TITLE
Fix occasional failure in refute_equal

### DIFF
--- a/lib/Test/Mini/Assertions.pm
+++ b/lib/Test/Mini/Assertions.pm
@@ -487,8 +487,8 @@ sub refute_equal ($$;$) {
         }
         elsif (ref $actual eq 'HASH' && ref $unexpected eq 'HASH') {
             $passed = (keys %$actual == keys %$unexpected);
-            unshift @actual, %$actual;
-            unshift @unexpected, %$unexpected;
+            unshift @actual,     map {$_, $actual->{$_}} sort keys %$actual;
+            unshift @unexpected, map {$_, $unexpected->{$_}} sort keys %$unexpected;
         }
         elsif (ref $actual && ref $unexpected) {
             $passed = (ref $actual eq ref $unexpected);


### PR DESCRIPTION
Hi, I'm participating in the [2015 CPAN Pull Request Challenge](http://blogs.perl.org/users/neilb/2014/12/take-the-2015-cpan-pull-request-challenge.html), and my assignment for January was Test::Mini.  As it turns out, I'm already a fan of minitest, and I think it's really neat that you brought yard over too. 

This pull request fixes an [occasional test failure](http://www.cpantesters.org/distro/T/Test-Mini.html?grade=3&perlmat=2&patches=2&oncpan=1&distmat=1&perlver=ALL&osname=ALL&version=v1.1.3) when comparing hashrefs with refute_equal; it wasn't sorting keys in the same way as assert_equal.

I believe this fixes Issue #11, which just happens to have confusing output in the test report because of deprecation warnings.

I do have a few other small changes I can submit in another PR, if you don't mind.  Thank you!
