### PR TITLE
Manage a distinct buffer for diagnostic messages.

### DIFF
--- a/lib/Test/Mini/Logger.pm
+++ b/lib/Test/Mini/Logger.pm
@@ -40,17 +40,6 @@ sub buffer {
     return $self->{buffer};
 }
 
-# @return [IO] Diagnostic output buffer.
-sub diag_buffer {
-    my ($self) = @_;
-    return $self->{diag_buffer} if defined $self->{diag_buffer};
-    return $self->{diag_buffer} = (
-        $ENV{HARNESS_VERBOSE}
-            ? $self->{buffer}
-            : IO::Handle->new_from_fd(fileno(STDERR),'w')
-    );
-}
-
 # @group Output Functions
 
 # Write output to the {#buffer}.
@@ -70,18 +59,6 @@ sub print {
 sub say {
     my ($self, @msg) = @_;
     $self->print(join("\n", @msg), "\n");
-}
-
-# Write output to the {#diag_buffer}.
-# Lines will be prepended with '# ' and separate messages will have newlines
-# appended.
-#
-# @param @msg The diagnostics to be printed.
-sub diag {
-    my ($self, @msgs) = @_;
-    my $msg = join "\n", @msgs;
-    $msg =~ s/^/# /mg;
-    $self->diag_buffer->print($msg, "\n");
 }
 
 # @group Callbacks

--- a/lib/Test/Mini/Logger.pm
+++ b/lib/Test/Mini/Logger.pm
@@ -43,7 +43,8 @@ sub buffer {
 # @return [IO] Diagnostic output buffer.
 sub diag_buffer {
     my ($self) = @_;
-    return $self->{diag_buffer} //= (
+    return $self->{diag_buffer} if defined $self->{diag_buffer};
+    return $self->{diag_buffer} = (
         $ENV{HARNESS_VERBOSE}
             ? $self->{buffer}
             : IO::Handle->new_from_fd(fileno(STDERR),'w')

--- a/lib/Test/Mini/Logger/TAP.pm
+++ b/lib/Test/Mini/Logger/TAP.pm
@@ -9,6 +9,17 @@ sub new {
     return $class->SUPER::new(test_counter => 0, %args);
 }
 
+# @return [IO] Diagnostic output buffer.
+sub diag_buffer {
+    my ($self) = @_;
+    return $self->{diag_buffer} if defined $self->{diag_buffer};
+    return $self->{diag_buffer} = (
+        $ENV{HARNESS_VERBOSE}
+            ? $self->{buffer}
+            : IO::Handle->new_from_fd(fileno(STDERR),'w')
+    );
+}
+
 sub test_counter {
     my ($self) = @_;
     return $self->{test_counter};
@@ -17,6 +28,18 @@ sub test_counter {
 sub inc_counter {
     my ($self) = @_;
     $self->{test_counter}++;
+}
+
+# Write output to the {#diag_buffer}.
+# Lines will be prepended with '# ' and separate messages will have newlines
+# appended.
+#
+# @param @msg The diagnostics to be printed.
+sub diag {
+    my ($self, @msgs) = @_;
+    my $msg = join "\n", @msgs;
+    $msg =~ s/^/# /mg;
+    $self->diag_buffer->print($msg, "\n");
 }
 
 sub begin_test_case {

--- a/lib/Test/Mini/Logger/TAP.pm
+++ b/lib/Test/Mini/Logger/TAP.pm
@@ -19,13 +19,6 @@ sub inc_counter {
     $self->{test_counter}++;
 }
 
-sub diag {
-    my ($self, @msgs) = @_;
-    my $msg = join "\n", @msgs;
-    $msg =~ s/^/# /mg;
-    $self->say($msg);
-}
-
 sub begin_test_case {
     my ($self, $tc, @tests) = @_;
     $self->diag("Test Case: $tc");

--- a/t/Test/Mini/Logger.t
+++ b/t/Test/Mini/Logger.t
@@ -13,10 +13,6 @@ my ($buffer, $logger);
 
 sub setup {
     $logger = Logger->new(buffer => Buffer->new(\($buffer = '')));
-
-    # For testing, we want to force output to one channel regardless of the
-    # actual test harness, so we're violating the interface a bit here.
-    $logger->{diag_buffer} = $logger->buffer;
 }
 
 sub test_full_test_run_should_remain_silent {
@@ -48,11 +44,6 @@ sub test_print {
 sub test_say {
     $logger->say(qw/foo bar baz/);
     assert_equal($buffer, "foo\nbar\nbaz\n");
-}
-
-sub test_diag {
-    $logger->diag(qw/foo bar baz/);
-    assert_equal($buffer, "# foo\n# bar\n# baz\n");
 }
 
 sub test_timings {

--- a/t/Test/Mini/Logger.t
+++ b/t/Test/Mini/Logger.t
@@ -13,6 +13,10 @@ my ($buffer, $logger);
 
 sub setup {
     $logger = Logger->new(buffer => Buffer->new(\($buffer = '')));
+
+    # For testing, we want to force output to one channel regardless of the
+    # actual test harness, so we're violating the interface a bit here.
+    $logger->{diag_buffer} = $logger->buffer;
 }
 
 sub test_full_test_run_should_remain_silent {
@@ -44,6 +48,11 @@ sub test_print {
 sub test_say {
     $logger->say(qw/foo bar baz/);
     assert_equal($buffer, "foo\nbar\nbaz\n");
+}
+
+sub test_diag {
+    $logger->diag(qw/foo bar baz/);
+    assert_equal($buffer, "# foo\n# bar\n# baz\n");
 }
 
 sub test_timings {

--- a/t/Test/Mini/Logger/TAP.t
+++ b/t/Test/Mini/Logger/TAP.t
@@ -14,7 +14,8 @@ my ($buffer, $logger);
 sub setup {
     $logger = Logger->new(buffer => Buffer->new(\($buffer = '')));
 
-    # Again, forcing single-channel output
+    # For testing, we want to force output to one channel regardless of the
+    # actual test harness, so we're violating the interface a bit here.
     $logger->{diag_buffer} = $logger->buffer;
 }
 
@@ -31,6 +32,11 @@ sub test_begin_test_case {
     assert_equal $buffer, tidy(q|
         # Test Case: MyClass
     |);
+}
+
+sub test_diag {
+    $logger->diag(qw/foo bar baz/);
+    assert_equal($buffer, "# foo\n# bar\n# baz\n");
 }
 
 sub test_pass {

--- a/t/Test/Mini/Logger/TAP.t
+++ b/t/Test/Mini/Logger/TAP.t
@@ -13,6 +13,9 @@ my ($buffer, $logger);
 
 sub setup {
     $logger = Logger->new(buffer => Buffer->new(\($buffer = '')));
+
+    # Again, forcing single-channel output
+    $logger->{diag_buffer} = $logger->buffer;
 }
 
 sub error { Test::Mini::Unit::Error->new(message => "Error Message\n") }


### PR DESCRIPTION
Hi, one more PR for you here.

I accidentally branched this off my other changes so I had to get back around to rebasing it off of master so the PR would stay clean.  This one probably needs a little more consideration than the others.

If you check out Issue #11, other than the misleading deprecation messages, there isn't actually any output indicating which tests failed or how.  I took a look at the TAP spec, which _does_ provide for in-band diagnostic output, then Test::Harness as well as the behavior of Test::More for precedent before working on this.

The changes below add an accessor named `diag_buffer` that lazily checks whether or not the test harness indicates it is in verbose mode -- if it is, we keep everything going to `$self->{buffer}`, as it will all be displayed in addition to the status of every test, and if it is not verbose, we open up STDERR so test output is concise but _which tests failed and why_ can still be seen.

Thanks for your time!
