### PR TITLE
Simplified Makefile.PL and converted doc to pod

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Revision history for Test-Mini
 
+v1.1.4  2015-07-??
+        Set min perl version in all modules and dist metadata to 5.006.
+        Previously Test::Mini required 5.008, but actually is fine with 5.006
+
 v1.1.3  2011-02-12
         Found a bug causing erroneous behavior for skipped tests in Perl 5.13+.
 

--- a/Changes
+++ b/Changes
@@ -3,6 +3,9 @@ Revision history for Test-Mini
 1.1.3_01 2015-07-24 NEILB
     - Set min perl version in all modules and dist metadata to 5.006.
       Previously Test::Mini required 5.008, but actually is fine with 5.006
+    - Updated Makefile.PL and MANIFEST to a simpler more static model;
+      this was made possible because Pieter is happy to drop use of Yard for
+      the documentation.
 
 v1.1.3 2011-02-13 PVANDE
     - Found a bug causing erroneous behavior for skipped tests in Perl 5.13+.

--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for Test-Mini
 
 1.1.3_01 2015-07-24 NEILB
+    - Converted all the documentation to traditional pod, from the Yard-based
+      documentation that was used previously.
     - Set min perl version in all modules and dist metadata to 5.006.
       Previously Test::Mini required 5.008, but actually is fine with 5.006
     - Updated Makefile.PL and MANIFEST to a simpler more static model;

--- a/Changes
+++ b/Changes
@@ -1,35 +1,35 @@
 Revision history for Test-Mini
 
-v1.1.4  2015-07-??
-        Set min perl version in all modules and dist metadata to 5.006.
-        Previously Test::Mini required 5.008, but actually is fine with 5.006
+1.1.3_01 2015-07-24 NEILB
+    - Set min perl version in all modules and dist metadata to 5.006.
+      Previously Test::Mini required 5.008, but actually is fine with 5.006
 
-v1.1.3  2011-02-12
-        Found a bug causing erroneous behavior for skipped tests in Perl 5.13+.
+v1.1.3 2011-02-13 PVANDE
+    - Found a bug causing erroneous behavior for skipped tests in Perl 5.13+.
 
-v1.1.2  2011-02-10
-        Fixed a bug in Makefile.PL that caused failures with older versions of
-        ExtUtils::MakeMaker.
+v1.1.2 2011-02-11 PVANDE
+    - Fixed a bug in Makefile.PL that caused failures with older versions of
+      ExtUtils::MakeMaker.
 
-        Added a proper $VERSION to the Test::Mini package.
+    - Added a proper $VERSION to the Test::Mini package.
 
-v1.1.1  2010-10-14
-        Fixed a bug w.r.t. mro::get_isarev behavior.  Test::Mini would always
-        try to run tests in any package that had ever been a subclass of
-        Test::Mini::TestCase; this prevented Test::Mini::Unit's tests from
-        passing under any Perl >= 5.9.5.  Few users will have seen this bug.
+v1.1.1 2010-10-15 PVANDE
+    - Fixed a bug w.r.t. mro::get_isarev behavior.  Test::Mini would always
+      try to run tests in any package that had ever been a subclass of
+      Test::Mini::TestCase; this prevented Test::Mini::Unit's tests from
+      passing under any Perl >= 5.9.5.  Few users will have seen this bug.
 
-        Made another pass at making t/Test/Mini/Logger.t pass on the smokers.
+    - Made another pass at making t/Test/Mini/Logger.t pass on the smokers.
 
-v1.1.0  2010-09-30
-        Implemented respect for the TEST_MINI_NO_AUTORUN environment variable
+v1.1.0 2010-10-01 PVANDE
+    - Implemented respect for the TEST_MINI_NO_AUTORUN environment variable
 
-        Fixed a bug where invalid TAP was output when running multiple test
-        cases in a single process
+    - Fixed a bug where invalid TAP was output when running multiple test
+      cases in a single process
 
-        Attempted once again to fix an intermittent failure in
-        t/Test/Mini/Logger.t related to timings
+    - Attempted once again to fix an intermittent failure in
+      t/Test/Mini/Logger.t related to timings
 
-v1.0.0  2010-09-16
-        First Major Version
+1.0.0  2010-09-16
+    - First Major Version
 

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,0 +1,14 @@
+Changes
+MANIFEST
+Makefile.PL
+README.pod
+lib/Test/Mini.pm
+lib/Test/Mini/Assertions.pm
+lib/Test/Mini/Logger.pm
+lib/Test/Mini/Runner.pm
+lib/Test/Mini/TestCase.pm
+lib/Test/Mini/Logger/TAP.pm
+t/01-Test-Mini.t
+t/Test/Mini/Assertions.t
+t/Test/Mini/Logger.t
+t/Test/Mini/Logger/TAP.t

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,10 +1,16 @@
 use strict;
 use warnings;
 
-BEGIN { require 5.008; } 
+BEGIN { require 5.006; } 
 
 use ExtUtils::MakeMaker 6.31;
 use ExtUtils::Manifest  1.56;
+
+my $mm_ver = $ExtUtils::MakeMaker::VERSION;
+if ($mm_ver =~ /_/) { # dev version
+    $mm_ver = eval $mm_ver;
+    die $@ if $@;
+}
 
 my $SKIP_FILES = <<SKIP;
 SKIP
@@ -45,6 +51,10 @@ my %WriteMakefileArgs = (
          'ExtUtils::MakeMaker' => '6.31',
          'ExtUtils::Manifest'  => '1.56',
     },
+    ($mm_ver >= 6.48
+        ? (MIN_PERL_VERSION => 5.006)
+        : ()
+    ),
 #   'DIST_REQUIRES' => {
 #       'ShipIt'                 => '0.55',
 #   },

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,10 +1,8 @@
+use 5.006;
 use strict;
 use warnings;
 
-BEGIN { require 5.006; } 
-
 use ExtUtils::MakeMaker 6.31;
-use ExtUtils::Manifest  1.56;
 
 my $mm_ver = $ExtUtils::MakeMaker::VERSION;
 if ($mm_ver =~ /_/) { # dev version
@@ -12,94 +10,72 @@ if ($mm_ver =~ /_/) { # dev version
     die $@ if $@;
 }
 
-my $SKIP_FILES = <<SKIP;
-SKIP
+my @REQUIRES = (
+    'base'             => 0,
+    'Data::Inspect'    => '0.03',
+    'Exception::Class' => '1.30',
+    'Getopt::Long'     => '2.38',
+    'List::Util'       => '1.33',
+    'MRO::Compat'      => '0.10',
+    'namespace::clean' => '0.14',
+    'Scalar::Util'     => '1.21',
+    'strict'           => 0,
+    'Time::HiRes'      => '1.9719',
+    'Try::Tiny'        => '0.04',
+    'warnings'         => 0,
+);
 
-my %WriteMakefileArgs = (
-    'NAME'       => 'Test::Mini',
-    'ABSTRACT'   => 'Lightweight xUnit Testing for Perl',
-    'VERSION'    => 'v1.1.3',
-    'AUTHOR'     => 'Pieter van de Bruggen <pvande@cpan.org>',
-    'LICENSE'    => 'perl',
+my @TEST_REQUIRES = (
+    'aliased'       => '0.30',
+    'B'             => '0',
+    'IO::Scalar'    => '2.110',
+    'Test::More'    => '0.96',
+    'Text::Outdent' => '0.01',
+);
+
+push(@REQUIRES, @TEST_REQUIRES) if $mm_ver < 6.64;
+
+WriteMakefile(
+    'NAME'          => 'Test::Mini',
+    'ABSTRACT'      => 'Lightweight xUnit Testing for Perl',
+    'VERSION_FROM'  => 'lib/Test/Mini.pm',
+    'AUTHOR'        => 'Pieter van de Bruggen <pvande@cpan.org>',
+
+    ($mm_ver >= 6.31
+        ? (LICENSE => 'perl')
+        : ()
+    ),
+
     'META_MERGE' => {
         'resources' => {
-            'homepage'   => 'http://github.com/pvande/Test-Mini',
-            'repository' => 'git://github.com/pvande/Test-Mini.git',
-            'bugtracker' => 'http://github.com/pvande/Test-Mini/issues',
+            'homepage'   => 'https://github.com/pvande/Test-Mini',
+            'repository' => 'https://github.com/pvande/Test-Mini.git',
+            'bugtracker' => 'https://github.com/pvande/Test-Mini/issues',
         },
     },
-    'PREREQ_PM' => {
-        'version'          => '0.77',
-        'Try::Tiny'        => '0.04',
-        'Scalar::Util'     => '1.21',
-        'List::Util'       => '1.33',
-        'MRO::Compat'      => '0.10',
-        'Getopt::Long'     => '2.38',
-        'Time::HiRes'      => '1.9719',
-        'Exception::Class' => '1.30',
-        'namespace::clean' => '0.14',
-        'Data::Inspect'    => '0.03',
-        'Text::Outdent'    => '0.01',
-    },
-    'BUILD_REQUIRES' => {
-        'Test::More' => '0.96',
-        'B'          => '0',
-        'aliased'    => '0.30',
-        'IO::Scalar' => '2.110',
-    },
-    'CONFIGURE_REQUIRES' => {
-         'ExtUtils::MakeMaker' => '6.31',
-         'ExtUtils::Manifest'  => '1.56',
-    },
+
+    'PREREQ_PM' => { @REQUIRES },
+
+    ($mm_ver >= 6.64
+        ? (TEST_REQUIRES => { @TEST_REQUIRES })
+        : ()
+    ),
+
+    ($mm_ver >= 6.52
+        ? (CONFIGURE_REQUIRES => {
+                'ExtUtils::MakeMaker' => 6.31,
+          })
+        : ()
+    ),
+
     ($mm_ver >= 6.48
         ? (MIN_PERL_VERSION => 5.006)
         : ()
     ),
-#   'DIST_REQUIRES' => {
-#       'ShipIt'                 => '0.55',
-#   },
+
     'test' => {
         'TESTS' => 't/*.t t/*/*.t t/*/*/*.t t/*/*/*/*.t t/*/*/*/*/*.t',
     },
-    'dist' => {
-        'PREOP'  => 'RUBYLIB=:../yard-perl-plugin/lib:../yard-pod-plugin/lib yard -e yard-perl-plugin.rb -e yard-pod-plugin.rb',
-        'POSTOP' => 'make realclean; rm MANIFEST',
-    },
+    'dist'        => { COMPRESS => 'gzip -6f', SUFFIX => 'gz', },
 );
 
-unless (eval { ExtUtils::MakeMaker->VERSION(6.56) }) {
-    my $REQS = delete $WriteMakefileArgs{BUILD_REQUIRES};
-    $WriteMakefileArgs{PREREQ_PM}->{$_} = $REQS->{$_} for keys %$REQS;
-}
-
-unless (eval { ExtUtils::MakeMaker->VERSION(6.52) }) {
-    my $REQS = delete $WriteMakefileArgs{CONFIGURE_REQUIRES};
-    $WriteMakefileArgs{PREREQ_PM}->{$_} = $REQS->{$_} for keys %$REQS;
-}
-
-(my $DISTNAME = $WriteMakefileArgs{NAME}) =~ s/::/-/g;
-my $DISTDIR = "$DISTNAME-$WriteMakefileArgs{VERSION}";
-my $LIBDIR = "$DISTDIR/lib";
-$WriteMakefileArgs{dist}->{PREOP} .= " -o $LIBDIR; ";
-$WriteMakefileArgs{dist}->{PREOP} .= "(cd $DISTDIR; find lib -name '*.pod' -type f >> MANIFEST)";
-
-# Create a MANIFEST.SKIP file.
-open(GITIGNORE, '<.gitignore');
-open(SKIP, '>MANIFEST.SKIP');
-print SKIP "#!include_default\n";
-print SKIP "MANIFEST.SKIP.*\n";
-print SKIP "^$DISTNAME.*\n";
-print SKIP "^\\..*\n";
-print SKIP <GITIGNORE>;
-print SKIP $SKIP_FILES;
-close SKIP;
-close GITIGNORE;
-
-# Create a new MANIFEST.
-ExtUtils::Manifest::mkmanifest();
-
-# Write the new Makefile.
-WriteMakefile(%WriteMakefileArgs);
-
-# Cleanup the MANIFEST.SKIP files.
-unlink glob 'MANIFEST.{,SKIP}*';

--- a/lib/Test/Mini.pm
+++ b/lib/Test/Mini.pm
@@ -1,54 +1,11 @@
-# Lightweight xUnit Testing for Perl.
-#
-# Test::Mini is a light, spry testing framework built to bring the familiarity
-# of an xUnit testing framework to Perl as a first-class citizen.  Based
-# initially on Ryan Davis' minitest, it provides a not only a simple way to
-# write and run tests, but the necessary infrastructure for more expressive
-# test fromeworks to be written.
-#
-# Since example code speaks louder than words:
-#
-#   package t::Test
-#   use base 'Test::Mini::TestCase';
-#   use strict;
-#   use warnings;
-#
-#   # This will run before each test
-#   sub setup { ... }
-#
-#   # This will run after each test
-#   sub teardown { ... }
-#
-#   sub test_something {
-#       my $self = shift;
-#       $self->assert(1); # Assertions come from Test::Mini::Assertions
-#   }
-#
-#   # Assertions can also be imported...
-#   use Test::Mini::Assertions;
-#
-#   sub helper { return 1 }
-#
-#   sub test_something_else {
-#       assert(helper());
-#   }
-#
-# Like any traditional xUnit framework, any method whose name begins with
-# 'test' will be automatically run.  If you've declared 'setup' or 'teardown'
-# methods, they will be run before or after each test.
-#
-# @see http://blog.zenspider.com/minitest
-# @see Test::Mini::Runner
-# @author Pieter van de Bruggen <pvande@cpan.org>
 package Test::Mini;
+
 use strict;
 use warnings;
 use 5.006;
 
-use version 0.77; our $VERSION = qv("v1.1.3");
+our $VERSION = '1.1.3_01';
 
-# @scope class
-# @return [Class] The test runner class to use.
 sub runner_class { 'Test::Mini::Runner' }
 
 END {
@@ -64,3 +21,89 @@ END {
 }
 
 1;
+
+__END__
+
+=head1 NAME
+
+Test::Mini - lightweight xUnit testing for Perl
+
+=head1 SYNOPSIS
+
+ use parent 'Test::Mini::TestCase';
+
+ sub setup    { ... }  # run before each test
+ sub teardown { ... }  # run after each test
+
+ sub test_something {
+   ...
+ }
+
+=head1 DESCRIPTION
+
+Test::Mini is a light, spry testing framework built to bring the familiarity
+of an xUnit testing framework to Perl as a first-class citizen.
+Based initially on Ryan Davis'
+L<minitest|https://github.com/seattlerb/minitest>,
+it provides a not only a simple way to
+write and run tests, but the necessary infrastructure for more expressive
+test fromeworks to be written.
+
+Since example code speaks louder than words:
+
+  package t::Test
+  use parent 'Test::Mini::TestCase';
+  use strict;
+  use warnings;
+
+  # This will run before each test
+  sub setup { ... }
+
+  # This will run after each test
+  sub teardown { ... }
+
+  sub test_something {
+      my $self = shift;
+      $self->assert(1); # Assertions come from Test::Mini::Assertions
+  }
+
+  # Assertions can also be imported...
+  use Test::Mini::Assertions;
+
+  sub helper { return 1 }
+
+  sub test_something_else {
+      assert(helper());
+  }
+
+Like any traditional xUnit framework, any method whose name begins with
+'test' will be automatically run.  If you've declared 'setup' or 'teardown'
+methods, they will be run before or after each test.
+
+=head1 CLASS METHODS
+
+=head2 runner_class
+
+Returns the name of the test runner class to use.
+
+=head1 SEE ALSO
+
+L<https://github.com/seattlerb/minitest>
+
+L<Test::Mini::Runner>
+
+=head1 REPOSITORY
+
+L<https://github.com/pvande/Test-Mini>
+
+=head1 AUTHOR
+
+Pieter van de Bruggen E<lt>pvande@cpan.orgE<gt>
+
+=head1 COPYRIGHT AND LICENSE
+
+This software is copyright (c) 2010 by Pieter van de Bruggen E<lt>pvande@cpan.orgE<gt>
+
+This is free software; you can redistribute it and/or modify it under
+the same terms as the Perl 5 programming language system itself.
+

--- a/lib/Test/Mini.pm
+++ b/lib/Test/Mini.pm
@@ -43,7 +43,7 @@
 package Test::Mini;
 use strict;
 use warnings;
-use 5.008;
+use 5.006;
 
 use version 0.77; our $VERSION = qv("v1.1.3");
 

--- a/lib/Test/Mini/Assertions.pm
+++ b/lib/Test/Mini/Assertions.pm
@@ -1,19 +1,20 @@
-# Raised on Test Error.
-# @api private
+#
+# First we define some cuckoo packages that we're going to use
+#
 package Test::Mini::Exception;
-use base 'Exception::Class::Base';
+use parent -norequire, 'Exception::Class::Base';
 
-# Raised on Test Failure.
-# @api private
 package Test::Mini::Exception::Assert;
-use base 'Test::Mini::Exception';
+use parent -norequire, 'Test::Mini::Exception';
 
-# Raised on Test Skip.
-# @api private
 package Test::Mini::Exception::Skip;
-use base 'Test::Mini::Exception::Assert';
+use parent -norequire, 'Test::Mini::Exception::Assert';
 
+#
+# And then we have the module proper itself
+#
 # Basic Assertions for Test::Mini.
+#
 package Test::Mini::Assertions;
 use 5.006;
 use strict;
@@ -23,12 +24,8 @@ use Scalar::Util      qw/ looks_like_number refaddr reftype /;
 use List::Util        qw/ min any /;
 use Data::Inspect;
 
-# Formats error messages, appending periods and defaulting undefs as
-# appropriate.
-#
-# @param $default [String] The default message to use.
-# @param $msg [String] A message to use in place of the default.
-# @return A well-formatted message.
+# Formats error messages,
+# appending periods and defaulting undefs as appropriate.
 sub message {
     my ($default, $msg) = @_;
 
@@ -39,9 +36,6 @@ sub message {
 }
 
 # Dereferences the given argument, if possible.
-#
-# @param $ref The argument to dereference.
-# @return The referenced value or values.
 sub deref {
     my ($ref) = @_;
     return %$ref if reftype($ref) eq 'HASH';
@@ -52,9 +46,6 @@ sub deref {
 }
 
 # Produce a more useful string representation of the given argument.
-#
-# @param $obj The object to describe.
-# @return [String] A description of the given object.
 sub inspect {
     Data::Inspect->new()->inspect(@_);
 }
@@ -86,18 +77,12 @@ sub _reset_assertions {
     return $final_count;
 }
 
-# @group Exported Functions
+# ========================
+# Exported Functions
+# ========================
 
-# Asserts that +$test+ is truthy, and throws a {Test::Mini::Exception::Assert}
+# Assert that $test is truthy, and throw a Test::Mini::Exception::Assert
 # if that assertion fails.
-#
-# @example
-#   assert 1;
-# @example
-#   assert 'true', 'Truth should shine clear';
-#
-# @param $test The value to test.
-# @param [String] $msg An optional description.
 sub assert ($;$) {
     my ($test, $msg) = @_;
     $msg ||= 'Assertion failed; no message given.';
@@ -113,16 +98,8 @@ sub assert ($;$) {
     );
 }
 
-# Asserts that +$test+ is falsey, and throws a {Test::Mini::Exception::Assert}
+# Asserts that $test is falsey, and throw a Test::Mini::Exception::Assert
 # if that assertion fails.
-#
-# @example
-#   refute 0;
-# @example
-#   refute undef, 'Deny the untruths';
-#
-# @param $test The value to test.
-# @param [String] $msg An optional description.
 sub refute ($;$) {
     my ($test, $msg) = @_;
     $msg ||= 'Refutation failed; no message given.';
@@ -130,17 +107,7 @@ sub refute ($;$) {
 }
 
 # Asserts that the given code reference returns a truthy value.
-#
-# @deprecated This assertion offers little advantage over the base {#assert}.
-#   This will be removed in v2.0.0.
-#
-# @example
-#   assert_block { 'true' };
-# @example
-#   assert_block \&some_sub, 'expected better from &some_sub';
-#
-# @param [CODE] $block The code reference to test.
-# @param [String] $msg An optional description.
+# DEPRECATED - this will be removed in v2.0.0.
 sub assert_block (&;$) {
     my ($block, $msg) = @_;
     warn '#assert_block is deprecated; please use #assert instead.';
@@ -151,17 +118,7 @@ sub assert_block (&;$) {
 }
 
 # Asserts that the given code reference returns a falsey value.
-#
-# @deprecated This assertion offers little advantage over the base {#refute}.
-#   This will be removed in v2.0.0.
-#
-# @example
-#   refute_block { '' };
-# @example
-#   refute_block \&some_sub, 'expected worse from &some_sub';
-#
-# @param [CODE] $block The code reference to test.
-# @param [String] $msg An optional description.
+# DEPRECATED - this will be removed in v2.0.0.
 sub refute_block (&;$) {
     my ($block, $msg) = @_;
     warn '#refute_block is deprecated; please use #refute instead.';
@@ -171,54 +128,23 @@ sub refute_block (&;$) {
     refute($block->(), $msg);
 }
 
-# Verifies that the given +$obj+ is capable of responding to the given
-# +$method+ name.
-#
-# @example
-#   assert_can $date, 'day_of_week';
-# @example
-#   assert_can $time, 'seconds', '$time cannot respond to #seconds';
-#
-# @param $obj The object being tested.
-# @param [String] $method The method name being checked for.
-# @param [String] $msg An optional description.
+# Verifies that the given $obj is capable of responding to the given
+# $method name.
 sub assert_can ($$;$) {
     my ($obj, $method, $msg) = @_;
     $msg = message("Expected @{[inspect($obj)]} (@{[ref $obj || 'SCALAR']}) to respond to #$method", $msg);
     assert($obj->can($method), $msg);
 }
 
-# Verifies that the given +$obj+ is *not* capable of responding to the given
-# +$method+ name.
-#
-# @example
-#   refute_can $date, 'to_time';
-# @example
-#   refute_can $time, 'day', '$time cannot respond to #day';
-#
-# @param $obj The object being tested.
-# @param [String] $method The method name being checked.
-# @param [String] $msg An optional description.
+# Verifies that the given $obj is *not* capable of responding to the given
+# $method name.
 sub refute_can ($$;$) {
     my ($obj, $method, $msg) = @_;
     $msg = message("Expected @{[inspect($obj)]} (@{[ref $obj || 'SCALAR']}) to not respond to #$method", $msg);
     refute($obj->can($method), $msg);
 }
 
-# Verifies that the given +$collection+ contains the given +$obj+ as a member.
-#
-# @example
-#   assert_contains [qw/ 1 2 3 /], 2;
-# @example
-#   assert_contains { a => 'b' }, 'a';  # 'b' also contained
-# @example
-#   assert_contains 'expectorate', 'xp';
-# @example
-#   assert_contains Collection->new(1, 2, 3), 2;  # if Collection->contains(2)
-#
-# @param [Array|Hash|String|#contains] $collection The collection to test.
-# @param $obj The needle to find.
-# @param [String] $msg An optional description.
+# Verifies that the given $collection contains the given $obj as a member.
 sub assert_contains ($$;$) {
     my ($collection, $obj, $msg) = @_;
     my $m = message("Expected @{[inspect($collection)]} to contain @{[inspect($obj)]}", $msg);
@@ -238,21 +164,8 @@ sub assert_contains ($$;$) {
     }
 }
 
-# Verifies that the given +$collection+ does not contain the given +$obj+ as a
+# Verifies that the given $collection does not contain the given $obj as a
 # member.
-#
-# @example
-#   refute_contains [qw/ 1 2 3 /], 5;
-# @example
-#   refute_contains { a => 'b' }, 'x';
-# @example
-#   refute_contains 'expectorate', 'spec';
-# @example
-#   refute_contains Collection->new(1, 2, 3), 5;  # unless Collection->contains(5)
-#
-# @param [Array|Hash|String|#contains] $collection The collection to test.
-# @param $obj The needle to look for.
-# @param [String] $msg An optional description.
 sub refute_contains ($$;$) {
     my ($collection, $obj, $msg) = @_;
     my $m = message("Expected @{[inspect($collection)]} to not contain @{[inspect($obj)]}", $msg);
@@ -272,34 +185,18 @@ sub refute_contains ($$;$) {
     }
 }
 
-# Validates that the given +$obj+ is defined.
-#
-# @example
-#   assert_defined $value;  # if defined $value
-#
-# @param $obj The value to check.
-# @param [String] $msg An optional description.
+# Validates that the given $obj is defined.
 sub assert_defined ($;$) {
     my ($obj, $msg) = @_;
     $msg = message("Expected @{[inspect($obj)]} to be defined", $msg);
     assert(defined $obj, $msg);
 }
 
-# Validates that the given +$obj+ is not defined.
-# @alias #assert_undef
+# Validates that the given $obj is not defined.
 sub refute_defined ($;$) { goto &assert_undef }
 
 # Tests that the supplied code block dies, and fails if it succeeds.  If
-# +$error+ is provided, the error message in +$@+ must contain it.
-#
-# @example
-#   assert_dies { die 'LAGHLAGHLAGHL' };
-# @example
-#   assert_dies { die 'Failure on line 27 in Foo.pm' } 'line 27';
-#
-# @param [CODE] $sub The code that should die.
-# @param [String] $error The (optional) error substring expected.
-# @param [String] $msg An optional description.
+# $error is provided, the error message in $@ must contain it.
 sub assert_dies (&;$$) {
     my ($sub, $error, $msg) = @_;
     $error = '' unless defined $error;
@@ -316,18 +213,6 @@ sub assert_dies (&;$$) {
 }
 
 # Verifies the emptiness of a collection.
-#
-# @example
-#   assert_empty [];
-# @example
-#   assert_empty {};
-# @example
-#   assert_empty '';
-# @example
-#   assert_empty Collection->new();  # if Collection->new()->is_empty()
-#
-# @param [Array|Hash|String|#is_empty] $collection The collection under scrutiny.
-# @param [String] $msg An optional description.
 sub assert_empty ($;$) {
     my ($collection, $msg) = @_;
     $msg = message("Expected @{[inspect($collection)]} to be empty", $msg);
@@ -347,18 +232,6 @@ sub assert_empty ($;$) {
 }
 
 # Verifies the non-emptiness of a collection.
-#
-# @example
-#   refute_empty [ 1 ];
-# @example
-#   refute_empty { a => 1 };
-# @example
-#   refute_empty 'full';
-# @example
-#   refute_empty Collection->new();  # unless Collection->new()->is_empty()
-#
-# @param [Array|Hash|String|#is_empty] $collection The collection under scrutiny.
-# @param [String] $msg An optional description.
 sub refute_empty ($;$) {
     my ($collection, $msg) = @_;
     $msg = message("Expected @{[inspect($collection)]} to not be empty", $msg);
@@ -378,29 +251,12 @@ sub refute_empty ($;$) {
 }
 
 # Checks two given arguments for equality.
-# @alias #assert_equal
 sub assert_eq { goto &assert_equal }
 
 # Checks two given arguments for inequality.
-# @alias #refute_equal
 sub refute_eq { goto &refute_equal }
 
 # Checks two given arguments for equality.
-#
-# @example
-#   assert_equal 3.000, 3;
-# @example
-#   assert_equal lc('FOO'), 'foo';
-# @example
-#   assert_equal [qw/ 1 2 3 /], [ 1, 2, 3 ];
-# @example
-#   assert_equal { a => 'eh' }, { a => 'eh' };
-# @example
-#   assert_equal Class->new(), $expected;  # if $expected->equals(Class->new())
-#
-# @param $actual The value under test.
-# @param $expected The expected value.
-# @param [String] $msg An optional description.
 sub assert_equal ($$;$) {
     my ($actual, $expected, $msg) = @_;
     $msg = message("Got @{[inspect($actual)]}\nnot @{[inspect($expected)]}", $msg);
@@ -448,21 +304,6 @@ sub assert_equal ($$;$) {
 }
 
 # Checks two given arguments for inequality.
-#
-# @example
-#   refute_equal 3.001, 3;
-# @example
-#   refute_equal lc('FOOL'), 'foo';
-# @example
-#   refute_equal [qw/ 1 23 /], [ 1, 2, 3 ];
-# @example
-#   refute_equal { a => 'ae' }, { a => 'eh' };
-# @example
-#   refute_equal Class->new(), $expected;  # unless $expected->equals(Class->new())
-#
-# @param $actual The value under test.
-# @param $expected The tested value.
-# @param [String] $msg An optional description.
 sub refute_equal ($$;$) {
     my ($actual, $unexpected, $msg) = @_;
     $msg = message("The given values were unexpectedly equal", $msg);
@@ -509,18 +350,8 @@ sub refute_equal ($$;$) {
     refute($passed, $msg);
 }
 
-# Checks that the difference between +$actual+ and +$expected+ is less than
-# +$delta+.
-#
-# @example
-#   assert_in_delta 1.001, 1;
-# @example
-#   assert_in_delta 104, 100, 5;
-#
-# @param [Number] $actual The tested value.
-# @param [Number] $expected The static value.
-# @param [Number] $delta The expected delta.  Defaults to 0.001.
-# @param [String] $msg An optional description.
+# Checks that the difference between $actual and $expected is less than
+# $delta.
 sub assert_in_delta ($$;$$) {
     my ($actual, $expected, $delta, $msg) = @_;
     $delta = 0.001 unless defined $delta;
@@ -529,19 +360,8 @@ sub assert_in_delta ($$;$$) {
     assert($delta >= $n, $msg);
 }
 
-# Checks that the difference between +$actual+ and +$expected+ is greater than
-# +$delta+.
-#
-# @example
-#   refute_in_delta 1.002, 1;
-# @example
-#   refute_in_delta 106, 100, 5;
-#
-# @param [Number] $actual The tested value.
-# @param [Number] $expected The static value.
-# @param [Number] $delta The delta +$actual+ and +$expected+ are expected to
-#   differ by.  Defaults to 0.001.
-# @param [String] $msg An optional description.
+# Checks that the difference between $actual and $expected is greater than
+# $delta.
 sub refute_in_delta ($$;$$) {
     my ($actual, $expected, $delta, $msg) = @_;
     $delta = 0.001 unless defined $delta;
@@ -550,18 +370,8 @@ sub refute_in_delta ($$;$$) {
     refute($delta >= $n, $msg);
 }
 
-# Checks that the difference between +$actual+ and +$expected+ is less than
+# Checks that the difference between $actual and $expected is less than
 # a given fraction of the smaller of the two numbers.
-#
-# @example
-#   assert_in_epsilon 22.0 / 7.0, Math::Trig::pi;
-# @example
-#   assert_in_epsilon 220, 200, 0.10
-#
-# @param [Number] $actual The tested value.
-# @param [Number] $expected The static value.
-# @param [Number] $epsilon The expected tolerance factor.  Defaults to 0.001.
-# @param [String] $msg An optional description.
 sub assert_in_epsilon ($$;$$) {
     my ($actual, $expected, $epsilon, $msg) = @_;
     $epsilon = 0.001 unless defined $epsilon;
@@ -573,19 +383,8 @@ sub assert_in_epsilon ($$;$$) {
     );
 }
 
-# Checks that the difference between +$actual+ and +$expected+ is greater than
+# Checks that the difference between $actual and $expected is greater than
 # a given fraction of the smaller of the two numbers.
-#
-# @example
-#   refute_in_epsilon 21.0 / 7.0, Math::Trig::pi;
-# @example
-#   refute_in_epsilon 220, 200, 0.20
-#
-# @param [Number] $actual The tested value.
-# @param [Number] $expected The static value.
-# @param [Number] $epsilon The factor by which +$actual+ and +$expected+ are
-#   expected to differ by.  Defaults to 0.001.
-# @param [String] $msg An optional description.
 sub refute_in_epsilon ($$;$$) {
     my ($actual, $expected, $epsilon, $msg) = @_;
     $epsilon = 0.001 unless defined $epsilon;
@@ -597,111 +396,63 @@ sub refute_in_epsilon ($$;$$) {
     );
 }
 
-# Verifies that the given +$collection+ contains the given +$obj+ as a member.
-# @alias #assert_contains
+# Verifies that the given $collection contains the given $obj as a member.
 sub assert_includes ($$;$) { goto &assert_contains }
 
-# Verifies that the given +$collection+ does not contain the given +$obj+ as a
+# Verifies that the given $collection does not contain the given $obj as a
 # member.
-# @alias #refute_includes
 sub refute_includes ($$;$) { goto &refute_contains }
 
-# Validates that the given object is an instance of +$type+.
-#
-# @example
-#   assert_instance_of MyApp::Person->new(), 'MyApp::Person';
-#
-# @param $obj The instance to check.
-# @param [Class] $type The type to expect.
-# @param [String] $msg An optional description.
-# @see #assert_is_a
+# Validates that the given object is an instance of $type.
 sub assert_instance_of ($$;$) {
     my ($obj, $type, $msg) = @_;
     $msg = message("Expected @{[inspect($obj)]} to be an instance of $type, not @{[ref $obj]}", $msg);
     assert(ref $obj eq $type, $msg);
 }
 
-# Validates that +$obj+ inherits from +$type+.
-#
-# @example
-#   assert_is_a 'Employee', 'Employee';
-# @example
-#   assert_is_a Employee->new(), 'Employee';
-# @example
-#   assert_is_a 'Employee', 'Person'; # assuming Employee->isa('Person')
-# @example
-#   assert_is_a Employee->new(), 'Person';
-#
-# @param $obj The instance or class to check.
-# @param [Class] $type The expected superclass.
-# @param [String] $msg An optional description.
+# Validates that $obj inherits from $type.
 sub assert_is_a($$;$) {
     my ($obj, $type, $msg) = @_;
     $msg = message("Expected @{[inspect($obj)]} to inherit from $type", $msg);
     assert($obj->isa($type), $msg);
 }
 
-# Validates that +$obj+ inherits from +$type+.
-# @alias #assert_is_a
+# Validates that $obj inherits from $type.
 sub assert_isa { goto &assert_is_a }
 
-# Validates that the given +$string+ matches the given +$pattern+.
-#
-# @example
-#   assert_match 'Four score and seven years ago...', qr/score/;
-#
-# @param [String] $string The string to match.
-# @param [Regex] $pattern The regular expression to match against.
-# @param [String] $msg An optional description.
+# Validates that the given $string matches the given $pattern.
 sub assert_match ($$;$) {
     my ($string, $pattern, $msg) = @_;
     $msg = message("Expected qr/$pattern/ to match against @{[inspect($string)]}", $msg);
     assert($string =~ $pattern, $msg);
 }
 
-# Validates that the given +$string+ does not match the given +$pattern+.
-#
-# @example
-#   refute_match 'Four score and seven years ago...', qr/score/;
-#
-# @param [String] $string The string to match.
-# @param [Regex] $pattern The regular expression to match against.
-# @param [String] $msg An optional description.
+# Validates that the given $string does not match the given $pattern.
 sub refute_match ($$;$) {
     my ($string, $pattern, $msg) = @_;
     $msg = message("Expected qr/$pattern/ to fail to match against @{[inspect($string)]}", $msg);
     refute($string =~ $pattern, $msg);
 }
 
-# Verifies that the given +$obj+ is capable of responding to the given
-# +$method+ name.
-# @alias #assert_can
+# Verifies that the given $obj is capable of responding to the given
+# $method name.
 sub assert_responds_to ($$;$) { goto &assert_can }
 
-# Verifies that the given +$obj+ is *not* capable of responding to the given
-# +$method+ name.
-# @alias #refute_can
+# Verifies that the given $obj is *not* capable of responding to the given
+# $method name.
 sub refute_responds_to ($$;$) { goto &refute_can }
 
-# Validates that the given +$obj+ is undefined.
-#
-# @example
-#   assert_undef $value;  # if not defined $value
-#
-# @param $obj The value to check.
-# @param [String] $msg An optional description.
+# Validates that the given $obj is undefined.
 sub assert_undef ($;$) {
     my ($obj, $msg) = @_;
     $msg = message("Expected @{[inspect($obj)]} to be undefined", $msg);
     refute(defined $obj, $msg);
 }
 
-# Validates that the given +$obj+ is not undefined.
-# @alias #assert_defined
+# Validates that the given $obj is not undefined.
 sub refute_undef ($;$) { goto &assert_defined }
 
 # Allows the current test to be bypassed with an indeterminate status.
-# @param [String] $msg An optional description.
 sub skip (;$) {
     my ($msg) = @_;
     $msg = 'Test skipped; no message given.' unless defined $msg;
@@ -713,7 +464,6 @@ sub skip (;$) {
 }
 
 # Causes the current test to exit immediately with a failing status.
-# @param [String] $msg An optional description.
 sub flunk (;$) {
     my ($msg) = @_;
     $msg = 'Epic failure' unless defined $msg;
@@ -721,3 +471,347 @@ sub flunk (;$) {
 }
 
 1;
+
+__END__
+
+=head1 NAME
+
+Test::Mini - base assertions for Test::Mini
+
+=head1 SYNOPSIS
+
+ use Test::Mini::Assertions;
+
+ assert($day_of_week eq 'Friday', 'Test should only be run on Friday!');
+
+=head1 DESCRIPTION
+
+This module provides a number of assertion functions,
+which are imported into your namespace when you use the module.
+
+All of these functions take an optional final argument, C<$msg>,
+which will be used as the text of the assertion, if specified.
+
+=head1 EXPORTED FUNCTIONS
+
+=head2 assert($test, $msg)
+
+Asserts that C<$test> is truthy,
+and throws a L<Test::Mini::Exception::Assert> if that assertion fails.
+For example:
+
+ assert 1;
+ assert 'true', 'Truth should shine clear';
+
+
+=head2 assert_block($block, $msg)
+
+Deprecated, as this function offers little advantage over the
+C<assert()> function, described above.
+
+Asserts that the given code reference returns a truthy value.
+For example:
+
+ assert_block { 'true' };
+
+ assert_block \&some_sub, 'expected better from &some_sub';
+
+
+=head2 assert_can($obj, $method, $msg)
+
+Verifies that the given C<$obj>
+is capable of responding to the given C<$method> name.
+
+Examples:
+
+ assert_can $date, 'day_of_week';
+ 
+ assert_can $time, 'seconds', '$time cannot respond to #seconds';
+
+This function is aliased as function C<assert_responds_to()>.
+
+
+=head2 assert_contains($collection, $obj, $msg)
+
+Verifies that the given C<$collection> contains the given C<$obj> as a member.
+
+Examples:
+
+ assert_contains [qw/ 1 2 3 /], 2;
+ assert_contains { a => 'b' }, 'a';  # 'b' also contained
+ assert_contains 'expectorate', 'xp';
+ assert_contains Collection->new(1, 2, 3), 2;  # if Collection->contains(2)
+
+The first argument, C<$collection>, can be an array, a hash,
+a string, or an object that provides a C<contains> method.
+
+This function is aliased as C<assert_includes()>.
+
+
+=head2 assert_defined($obj, $msg)
+
+Validates that the given C<$obj> is defined.
+
+Example:
+
+ assert_defined $value;
+
+This function is aliased as C<refute_undef()>.
+
+
+=head2 assert_dies($sub, $error, $msg)
+
+Tests that the supplied code block dies, and fails if it succeeds.
+If C<$error> is provided, the error message in C<$@> must contain it.
+
+Examples:
+
+ assert_dies { die 'LAGHLAGHLAGHL' };
+ assert_dies { die 'Failure on line 27 in Foo.pm' } 'line 27';
+
+
+=head2 assert_empty($collection, $msg)
+
+Verifies the emptiness of a collection.
+
+Examples:
+
+ assert_empty [];
+ assert_empty {};
+ assert_empty '';
+ assert_empty Collection->new();  # if Collection->new()->is_empty()
+
+
+=head2 assert_equal($actual, $expected, $msg)
+
+Checks two given arguments for equality.
+The first argument, C<$actual>, is the value being tested
+(eg has been calculated by code under test),
+and the second argument gives the expected value.
+
+Examples:
+
+ assert_equal 3.000, 3;
+ assert_equal lc('FOO'), 'foo';
+ assert_equal [qw/ 1 2 3 /], [ 1, 2, 3 ];
+ assert_equal { a => 'eh' }, { a => 'eh' };
+
+ # if $expected->equals(Class->new())
+ assert_equal Class->new(), $expected;
+
+This function is also aliased as C<assert_eq()>.
+
+
+=head2 assert_in_delta($actual, $expected, $delta, $msg)
+
+Checks that the difference between C<$actual> and C<$expected>
+is less than C<$delta>.
+
+Examples:
+
+ assert_in_delta 1.001, 1;
+ assert_in_delta 104, 100, 5;
+
+
+=head2 assert_in_epsilon($actual, $expected, $epsilon, $msg)
+
+Checks that the difference between C<$actual> and C<$expected>
+is less than a given fraction of the smaller of the two numbers.
+
+Examples:
+
+ assert_in_epsilon 22.0 / 7.0, Math::Trig::pi;
+ assert_in_epsilon 220, 200, 0.10;
+
+If C<$epsilon> isn't given, it defaults to 0.001.
+
+
+=head2 assert_instance_of($object, $type, $msg)
+
+Validates that the given C<$object> is an instance of C<$type>.
+
+Examples:
+
+ my $object = MyApp::Person->new();
+ assert_instance_of $object, 'MyApp::Person';
+
+
+=head2 assert_is_a($obj, $type, $msg)
+
+Validates that C<$obj> inherits from C<$type>.
+
+Examples:
+
+ assert_is_a 'Employee', 'Employee';
+ assert_is_a Employee->new(), 'Employee';
+ assert_is_a 'Employee', 'Person'; # assuming Employee->isa('Person')
+ assert_is_a Employee->new(), 'Person';
+
+This function is also available as C<assert_isa()>.
+
+
+=head2 assert_match($string, $pattern, $msg)
+
+Validates that the given C<$string> matches the given C<$pattern>.
+
+Examples:
+
+ assert_match 'Four score and seven years ago...', qr/score/;
+
+
+=head2 assert_undef($obj, $msg)
+
+Validates that the given C<$obj> is undefined.
+
+Examples:
+
+ assert_undef $value;  # if not defined $value
+
+Also available as C<refute_defined()>.
+
+
+=head2 flunk($msg)
+
+Causes the current test to exit immediately with a failing status.
+
+
+=head2 refute($test, $msg)
+
+Asserts that C<$test> is falsey,
+and throws a L<Test::Mini::Exception::Assert> if that assertion fails.
+
+Examples:
+
+ refute 0;
+ refute undef, 'Deny the untruths';
+
+
+=head2 refute_block($block, $msg) 
+  
+B<Deprecated>:
+This assertion offers little advantage over the base C<refute()>.
+This will be removed in v2.0.0.
+
+Asserts that the given code reference returns a falsey value.
+
+Examples:
+
+ refute_block { '' };
+ refute_block \&some_sub, 'expected worse from &some_sub';
+
+
+=head2 refute_can($obj, $method, $msg)
+
+Verifies that the given C<$obj> is not capable of responding
+to the given C<$method> name.
+
+Examples:
+
+ refute_can $date, 'to_time';
+ refute_can $time, 'day', '$time cannot respond to #day';
+
+Also available as C<refute_responds_to()>.
+
+
+=head2 refute_contains($collection, $obj, $msg)
+
+Verifies that the given C<$collection> does not contain the given
+C<$obj> as a member.
+
+Examples:
+
+ refute_contains [qw/ 1 2 3 /], 5;
+ refute_contains { a => 'b' }, 'x';
+ refute_contains 'expectorate', 'spec';
+ refute_contains Collection->new(1, 2, 3), 5;  # unless Collection->contains(5)
+
+The C<$collection> can be a hash ref, an array ref, a string,
+or an instance of a class that provides a C<contains()> method.
+
+
+=head2 refute_empty($collection, $msg)
+
+Verifies the non-emptiness of a collection.
+
+Examples:
+
+ refute_empty [ 1 ];
+ refute_empty { a => 1 };
+ refute_empty 'full';
+ refute_empty Collection->new();  # unless Collection->new()->is_empty()
+
+See the description for C<refute_contains()> above for
+what C<$collection> can be.
+
+
+=head2 refute_equal($actual, $unexpected, $msg)
+
+Checks two given arguments for inequality.
+
+Examples:
+
+ refute_equal 3.001, 3;
+ refute_equal lc('FOOL'), 'foo';
+ refute_equal [qw/ 1 23 /], [ 1, 2, 3 ];
+ refute_equal { a => 'ae' }, { a => 'eh' };
+ refute_equal Class->new(), $expected;  # unless $expected->equals(Class->new())
+
+Also available as C<refute_eq()>.
+
+
+=head2 refute_in_delta($actual, $expected, $delta, $msg)
+
+Checks that the difference between C<$actual> and C<$expected>
+is greater than C<$delta>.
+
+Examples:
+
+ refute_in_delta 1.002, 1;
+ refute_in_delta 106, 100, 5;
+
+
+=head2 refute_in_epsilon($actual, $expected, $epsilon, $msg)
+
+Checks that the difference between C<$actual> and C<$expected>
+is greater than a given fraction of the smaller of the two numbers.
+
+Examples:
+
+ refute_in_epsilon 21.0 / 7.0, Math::Trig::pi;
+ refute_in_epsilon 220, 200, 0.20
+
+
+=head2 refute_match($string, $pattern, $msg)
+
+Validates that the given C<$string> does not match the given C<$pattern>.
+
+Examples:
+
+ refute_match 'Four score and seven years ago...', qr/score/;
+
+
+=head2 skip($msg)
+
+Allows the current test to be bypassed with an indeterminate status.
+
+
+=head1 SEE ALSO
+
+L<Test::Mini>
+
+=head1 REPOSITORY
+
+L<https://github.com/pvande/Test-Mini>
+
+=head1 AUTHOR
+
+Pieter van de Bruggen E<lt>pvande@cpan.orgE<gt>
+
+=head1 COPYRIGHT AND LICENSE
+
+This software is copyright (c) 2010 by Pieter van de Bruggen
+E<lt>pvande@cpan.orgE<gt>
+
+This is free software; you can redistribute it and/or modify it under
+the same terms as the Perl 5 programming language system itself.
+

--- a/lib/Test/Mini/Assertions.pm
+++ b/lib/Test/Mini/Assertions.pm
@@ -15,6 +15,7 @@ use base 'Test::Mini::Exception::Assert';
 
 # Basic Assertions for Test::Mini.
 package Test::Mini::Assertions;
+use 5.006;
 use strict;
 use warnings;
 

--- a/lib/Test/Mini/Logger.pm
+++ b/lib/Test/Mini/Logger.pm
@@ -4,6 +4,7 @@
 # just long for the familiar look and feel of another testing framework, this
 # is what you're looking for.
 package Test::Mini::Logger;
+use 5.006;
 use strict;
 use warnings;
 

--- a/lib/Test/Mini/Logger.pm
+++ b/lib/Test/Mini/Logger.pm
@@ -1,20 +1,11 @@
-# Output Logger Base Class.
-#
-# Whether you're using a tool that expects output in a certain format, or you
-# just long for the familiar look and feel of another testing framework, this
-# is what you're looking for.
 package Test::Mini::Logger;
+
 use 5.006;
 use strict;
 use warnings;
 
 use Time::HiRes;
 
-# Constructor.
-#
-# @param [Hash] %args Initial state for the new instance.
-# @option %args verbose (0) Logger verbosity.
-# @option %args buffer [IO] (STDOUT) Output buffer.
 sub new {
     my ($class, %args) = @_;
     return bless {
@@ -26,77 +17,57 @@ sub new {
     }, $class;
 }
 
-# @group Attribute Accessors
+# ===========================
+# Attribute Accessors
+# ===========================
 
-# @return Logger verbosity.
 sub verbose {
     my ($self) = @_;
     return $self->{verbose};
 }
 
-# @return [IO] Output buffer.
 sub buffer {
     my ($self) = @_;
     return $self->{buffer};
 }
 
-# @group Output Functions
+# ===========================
+# Output Functions
+# ===========================
 
-# Write output to the {#buffer}.
-# Lines will be output without added newlines.
-#
-# @param @msg The message(s) to be printed; will be handled as per +print+.
 sub print {
     my ($self, @msg) = @_;
     print { $self->buffer() } @msg;
 }
 
-# Write output to the {#buffer}.
-# Lines will be output with appended newlines.
-#
-# @param @msg The message(s) to be printed; newlines will be appended to each
-#   message, before being passed to {#print}.
 sub say {
     my ($self, @msg) = @_;
     $self->print(join("\n", @msg), "\n");
 }
 
-# @group Callbacks
+# ===========================
+# Callbacks
+# ===========================
 
 # Called before the test suite is run.
-#
-# @param [Hash] %args Options the test suite was run with.
-# @option %args [String] filter Test name filter.
-# @option %args [String] seed Randomness seed.
 sub begin_test_suite {
     my ($self, %args) = @_;
     $self->{times}->{$self} = -Time::HiRes::time();
 }
 
 # Called before each test case is run.
-#
-# @param [Class] $tc The test case being run.
-# @param [Array<String>] @tests A list of tests to be run.
 sub begin_test_case {
     my ($self, $tc, @tests) = @_;
     $self->{times}->{$tc} = -Time::HiRes::time();
 }
 
 # Called before each test is run.
-#
-# @param [Class] $tc The test case owning the test method.
-# @param [String] $test The name of the test method being run.
 sub begin_test {
     my ($self, $tc, $test) = @_;
     $self->{times}->{"$tc#$test"} = -Time::HiRes::time();
 }
 
 # Called after each test is run.
-# Increments the test and assertion counts, and finalizes the test's timing.
-#
-# @param [Class] $tc The test case owning the test method.
-# @param [String] $test The name of the test method just run.
-# @param [Integer] $assertions The number of assertions called.
 sub finish_test {
     my ($self, $tc, $test, $assertions) = @_;
     $self->{count}->{test}++;
@@ -105,10 +76,6 @@ sub finish_test {
 }
 
 # Called after each test case is run.
-# Increments the test case count, and finalizes the test case's timing.
-#
-# @param [Class] $tc The test case just run.
-# @param [Array<String>] @tests A list of tests run.
 sub finish_test_case {
     my ($self, $tc, @tests) = @_;
     $self->{count}->{test_case}++;
@@ -116,83 +83,260 @@ sub finish_test_case {
 }
 
 # Called after each test suite is run.
-# Finalizes the test suite timing.
-#
-# @param [Integer] $exit_code Status the tests finished with.
 sub finish_test_suite {
     my ($self, $exit_code) = @_;
     $self->{times}->{$self} += Time::HiRes::time();
 }
 
 # Called when a test passes.
-# Increments the pass count.
-#
-# @param [Class] $tc The test case owning the test method.
-# @param [String] $test The name of the passing test.
 sub pass {
     my ($self, $tc, $test) = @_;
     $self->{count}->{pass}++;
 }
 
 # Called when a test is skipped.
-# Increments the skip count.
-#
-# @param [Class] $tc The test case owning the test method.
-# @param [String] $test The name of the skipped test.
-# @param [Test::Mini::Exception::Skip] $e The exception object.
 sub skip {
     my ($self, $tc, $test, $e) = @_;
     $self->{count}->{skip}++;
 }
 
 # Called when a test fails.
-# Increments the failure count.
-#
-# @param [Class] $tc The test case owning the test method.
-# @param [String] $test The name of the failed test.
-# @param [Test::Mini::Exception::Assert] $e The exception object.
 sub fail {
     my ($self, $tc, $test, $e) = @_;
     $self->{count}->{fail}++;
 }
 
 # Called when a test dies with an error.
-# Increments the error count.
-#
-# @param [Class] $tc The test case owning the test method.
-# @param [String] $test The name of the test with an error.
-# @param [Test::Mini::Exception] $e The exception object.
 sub error {
     my ($self, $tc, $test, $e) = @_;
     $self->{count}->{error}++;
 }
 
-# @group Statistics
+# ===========================
+# Statistics
+# ===========================
 
 # Accessor for counters.
-#
-# @overload count()
-#   @return [Hash] The count hash.
-#
-# @overload count($key)
-#   @param $key A key in the count hash.
-#   @return [Number] The value for the given key.
 sub count {
     my ($self, $key) = @_;
     return ($key ? $self->{count}->{$key} : $self->{count}) || 0;
 }
 
 # Accessor for the timing data.
-#
-# @param $key The key to look up timings for.  Typical values are:
-#   +$self+ :: Time for test suite
-#   "TestCase" :: Time for the test case
-#   "TestCase#test" :: Time for the given test
-#   Times for units that have not finished should not be relied upon.
-# @return [Number] The time taken by the given argument, in seconds.
 sub time {
     my ($self, $key) = @_;
     return $self->{times}->{$key};
 }
 
 1;
+
+__END__
+
+=head1 NAME
+
+Test::Mini::Logger - output logger base class for Test::Mini
+
+=head1 DESCRIPTION
+
+This module is the base class for loggers that are going to be
+used with L<Test::Mini>. By default, C<Test::Mini> uses this
+class directly, but you can subclass it and ask C<Test::Mini>
+to use your class instead.
+
+
+=head1 CLASS METHODS
+
+=head2 new(%args)
+
+Constructor. Takes a hash of arguments providing initial state.
+Valid keys are:
+
+=over 4
+
+=item verbose - logger verbosity, defaulting to 0
+
+=item buffer - output buffer, defaults to STDOUT.
+
+=back
+
+
+=head1 ATTRIBUTE ACCESSORS
+
+=head2 buffer
+
+Returns the output buffer.
+
+=head2 verbose
+
+Returns logger verbosity.
+
+
+=head1 OUTPUT METHODS
+
+=head2 print(@msg)
+
+Write output to the C<buffer>.
+Takes an array of strings, which will be output to C<buffer> without
+adding any newlines.
+
+=head2 say(@msg)
+
+Writes output, adding a newline character to each entry in C<@msg>.
+
+
+=head1 CALLBACKS
+
+=head2 begin_test($tc, $test)
+
+Called before each test is run.
+C<$tc> is the test case owning the test method,
+and C<$test> is the name of the test method being run.
+
+=head2 begin_test_case($tc, @tests)
+
+Called before each test case is run.
+C<$tc> is the test case being run, and C<@tests> is a list of tests
+to be run.
+
+=head2 begin_test_suite(%args)
+
+Called before the test suite is run. Takes a hash of arguments,
+valid keys for which are:
+
+=over 4
+
+=item filter - test name filter.
+
+=item seed - seed for the random number generator.
+
+=back
+
+
+=head2 error($tc, $test, $e)
+
+Called when a test dies with an error. Increments the error count.
+Takes three arguments:
+
+=over 4
+
+=item $tc - the test case owning the test method.
+
+=item $test - the name of the test with an error.
+
+=item $e - the exception object, an instance of L<Test::Mini::Exception>.
+
+=back
+
+
+=head2 fail($tc, $test, $e)
+
+Called when a test fails. Increments the failure count.
+Takes the same three arguments as C<error()>, above.
+
+
+=head2 finish_test($tc, $test, $assertions)
+
+Called after each test is run.
+Increments the test and assertion counts, and finalizes the test's timing.
+Takes three parameters:
+
+=over 4
+
+=item $tc -- The test case owning the test method.
+
+=item $test -- The name of the test method just run.
+
+=item $assertions -- The number of assertions called.
+
+=back
+
+
+=head2 finish_test_case($tc, @tests)
+
+Called after each test case is run.
+Increments the test case count, and finalizes the test case's timing.
+Takes two arguments:
+
+=over 4
+
+=item $tc - the test case just run.
+
+=item @tests - a list of tests run.
+
+=back
+
+
+=head2 finish_test_suite($exit_code)
+
+Called after each test suite is run. Finalizes the test suite timing.
+Takes one argument, which is the C<$exit_code> that the tests finished with.
+
+
+=head2 pass($tc, $test)
+
+Called when a test passes. Increments the pass count.
+Takes two arguments:
+
+=over 4
+
+=item $tc - the test case owning the test method.
+
+=item $test - the name of the passing test.
+
+=back
+
+
+=head2 skip($tc, $test, $e)
+
+Called when a test is skipped. Increments the skip count.
+Takes the same three arguments as the C<error()> method,
+described above.
+
+
+=head1 STATISTICS
+
+=head2 count
+
+If called with no arguments, this returns the hash of all counters.
+If you pass the name of one test, it returns just the count for
+the named test.
+
+=head2 time($key)
+
+Used to retrieve timing data for a test suite, test case, or specific test.
+You can pass one of three argument types:
+
+=over 4
+
+=item $self - returns the time for the test suite.
+
+=item "TestCase" - returns time for the test case.
+
+=item "TestCase#test" - returns time for the given test in the test case.
+
+=back
+
+Times for units that have not finished should not be relied upon.
+
+Returns the time taken by the given argument, in seconds.
+
+=head1 SEE ALSO
+
+L<Test::Mini>
+
+=head1 REPOSITORY
+
+L<https://github.com/pvande/Test-Mini>
+
+=head1 AUTHOR
+
+Pieter van de Bruggen E<lt>pvande@cpan.orgE<gt>
+
+=head1 COPYRIGHT AND LICENSE
+
+This software is copyright (c) 2010
+by Pieter van de Bruggen E<lt>pvande@cpan.orgE<gt>
+
+This is free software; you can redistribute it and/or modify it under
+the same terms as the Perl 5 programming language system itself.
+

--- a/lib/Test/Mini/Logger/TAP.pm
+++ b/lib/Test/Mini/Logger/TAP.pm
@@ -1,9 +1,11 @@
 # Default Test::Mini Output Logger.
 package Test::Mini::Logger::TAP;
+
 use 5.006;
-use base 'Test::Mini::Logger';
 use strict;
 use warnings;
+
+use parent 'Test::Mini::Logger';
 
 sub new {
     my ($class, %args) = @_;

--- a/lib/Test/Mini/Logger/TAP.pm
+++ b/lib/Test/Mini/Logger/TAP.pm
@@ -1,5 +1,6 @@
 # Default Test::Mini Output Logger.
 package Test::Mini::Logger::TAP;
+use 5.006;
 use base 'Test::Mini::Logger';
 use strict;
 use warnings;

--- a/lib/Test/Mini/Runner.pm
+++ b/lib/Test/Mini/Runner.pm
@@ -1,34 +1,4 @@
-# Default Test Runner.
-#
-# The Test::Mini::Runner is responsible for finding and running the
-# appropriate tests, setting up output logging, and returning an appropriate
-# status code.  For those looking to write tests with this framework, the
-# points of note are as follows:
-#
-# * Tests are run automatically at process exit.
-# * All test cases (subclasses of {Test::Mini::TestCase}) that have been
-#   loaded at that time will be considered.  This includes indirect
-#   subclasses.
-# * Within each test case, all methods defined with a name matching
-#   <tt>/^test.+/</tt> will be run.
-#   * Each test will run in its own test case instance.
-#   * Tests will be run in random order.
-#   * #setup will be called before each test is run.
-#   * #teardown will be called after each test is run.
-#   * Inherited tests are *not* run.
-# * Tests may be run via +`prove`+, by loading (via +use+, +do+ or +require+)
-#   the files into another script, or by simply executing a file containing a
-#   test case in the Perl interpreter.
-#   * If you want to use a non-TAP output logger, +`prove`+ is not an option.
-# * Options may be passed in either as command line options, or as environment
-#   variables.
-#   * Environment variable names are prefixed with 'TEST_MINI_'.
-#   * Valid options are:
-#     * +verbose+ - Specifies the logger's verbosity.
-#     * +filter+ - Only tests with names matching this pattern should be run.
-#     * +logger+ - Specifies an alternate output logger class.
-#     * +seed+ - Specifies a random number seed; used to specify repeatable
-#       test orderings.
+
 package Test::Mini::Runner;
 use 5.006;
 use strict;
@@ -40,16 +10,6 @@ use MRO::Compat;
 use Test::Mini::TestCase;
 use List::Util qw/ shuffle /;
 
-# Constructor.
-# Arguments may be provided explicitly to the constructor or implicitly via
-# either @ARGV (parsed by {Getopt::Long}) or environment variables
-# ("TEST_MINI_$option").
-#
-# @param [Hash] %args Initial state for the new instance.
-# @option %args verbose (0) Logger verbosity.
-# @option %args filter [String] ('')  Test name filter.
-# @option %args logger [Class] (Test::Mini::Logger::TAP) Logger class name.
-# @option %args seed [Integer] (a random number +< 64_000_000+) Randomness seed.
 sub new {
     my ($class, %args) = @_;
 
@@ -231,3 +191,232 @@ sub error {
 }
 
 1;
+
+__END__
+
+=head1 NAME
+
+Test::Mini::Runner - default test runner for Test::Mini test cases
+
+=head1 DESCRIPTION
+
+This module is responsible for finding and running the appropriate tests,
+setting up output logging, and returning an appropriate status code.
+For those looking to write tests with this framework,
+the points of note are as follows:
+
+=over 4
+
+=item * Tests are run automatically at process exit.
+
+=item * All test cases (subclasses of {Test::Mini::TestCase}) that have been
+loaded at that time will be considered.  This includes indirect
+subclasses.
+
+=item * Within each test case, all methods defined with a name matching
+C</^test.+/> will be run.
+
+=over 4
+
+=item * Each test will run in its own test case instance.
+
+=item * Tests will be run in random order.
+
+=item * The C<setup()> method will be called before each test is run.
+
+=item * The C<teardown()> will be called after each test is run.
+
+=item * Inherited tests are I<not> run.
+
+=back
+
+=item * Tests may be run via
+L<prove|https://metacpan.org/pod/distribution/Test-Harness/bin/prove>,
+by loading (via C<use>, C<do> or C<require>)
+the files into another script, or by simply executing a file containing a
+test case in the Perl interpreter.
+
+=over 4
+
+=item * If you want to use a non-TAP output logger, C<prove> is not an option.
+
+=back
+
+=item * Options may be passed in either as command line options,
+or as environment variables.
+
+=over 4
+
+=item * Environment variable names are prefixed with C<TEST_MINI_>.
+
+=item * Valid options are:
+
+=item * C<verbose> - Specifies the logger's verbosity.
+
+=item * C<filter> - Only tests with names matching this pattern should be run.
+
+=item * C<logger> - Specifies an alternate output logger class.
+
+=item * C<seed> - Specifies a random number seed; used to specify repeatable
+test orderings.
+
+=back
+
+=back
+
+
+=head1 CLASS METHODS
+
+=head2 new(%args)
+
+Constructor.
+Arguments may be provided explicitly to the constructor or implicitly via
+either C<@ARGV> (parsed by L<Getopt::Long>) or environment variables
+(C<TEST_MINI_$option>).
+
+The following arguments are supported:
+
+=over 4
+
+=item verbose
+
+Logger verbosity. Defaults to 0.
+
+=item filter
+
+Test name filter. Defaults to ''.
+
+=item logger
+
+Logger class name. Defaults to L<Test::Mini::Logger::TAP>.
+
+=item seed
+
+Randomness seed. Defaults to a random number C<E<lt> 64_000_000>.
+
+=back
+
+
+=head1 ATTRIBUTE ACCESSORS
+
+=head2 exit_code
+
+Returns the exit code, representing the status of the test run.
+
+=head2 filter
+
+Test name filter.
+
+=head2 logger
+
+Logger instance.
+
+=head2 seed
+
+Randomness seed.
+
+=head2 verbose
+
+Logger verbosity
+
+
+=head1 TEST RUN HOOKS
+
+=head2 run
+
+Begins the test run.
+Loads and instantiates the test output logger, then dispatches to
+C<run_test_suite()> (passing the C<filter> and C<seed>, as appropriate).
+
+Returns the result of the C<run_test_suite> call.
+
+
+=head2 run_test($tc, $test)
+
+Runs a specific test. Takes two arguments, which identify the test to run:
+
+=over 4
+
+=item C<$tc>
+
+The test case owning the test method.
+
+=item C<$test>
+
+The name of the test method to be run.
+
+=back
+
+Returns the number of assertions called by the test.
+
+
+=head2 run_test_suite(%args)
+
+Runs the test suite.
+Finds subclasses of L<Test::Mini::TestCase>,
+and dispatches to C<run_test_case()> with the name of each test case
+and a list test methods to be run.
+
+Can be passed a hash of arguments; the following keys are understood:
+
+=over 4
+
+=item filter - test name filter.
+
+=item seed - seed for the random number generator.
+
+=back
+
+Returns the value of C<exit_code()>.
+
+
+=head1 CALLBACKS
+
+=head2 error($tc, $test, $e)
+
+Callback for dying tests. Takes three arguments:
+
+=over 4
+
+=item C<$tc> - the test case owning the test method.
+
+=item C<$test> - the name of the failed test.
+
+=item C<$e> - the exception object,
+an instance of L<Test::Mini::Exception::Assert>.
+
+=back
+
+
+=head2 pass($tc, $test)
+
+Callback for passing tests. Takes two arguments: C<$tc> is the test case
+owning the test method, and C<$test> is the name of the passing test.
+
+
+=head2 skip($tc, $test, $e)
+
+Callback for skipped tests. The arguments are the same as those for
+the C<error()> method, above.
+
+
+=head1 SEE ALSO
+
+L<Test::Mini>
+
+=head1 REPOSITORY
+
+L<https://github.com/pvande/Test-Mini>
+
+=head1 AUTHOR
+
+Pieter van de Bruggen E<lt>pvande@cpan.orgE<gt>
+
+=head1 COPYRIGHT AND LICENSE
+
+This software is copyright (c) 2010 by
+Pieter van de Bruggen E<lt>pvande@cpan.orgE<gt>
+
+This is free software; you can redistribute it and/or modify it under
+the same terms as the Perl 5 programming language system itself.
+

--- a/lib/Test/Mini/Runner.pm
+++ b/lib/Test/Mini/Runner.pm
@@ -30,6 +30,7 @@
 #     * +seed+ - Specifies a random number seed; used to specify repeatable
 #       test orderings.
 package Test::Mini::Runner;
+use 5.006;
 use strict;
 use warnings;
 

--- a/lib/Test/Mini/TestCase.pm
+++ b/lib/Test/Mini/TestCase.pm
@@ -2,6 +2,7 @@
 #
 # @see Test::Mini::Runner
 package Test::Mini::TestCase;
+use 5.006;
 use strict;
 use warnings;
 

--- a/lib/Test/Mini/TestCase.pm
+++ b/lib/Test/Mini/TestCase.pm
@@ -1,7 +1,5 @@
-# Base class for Test::Mini test cases.
-#
-# @see Test::Mini::Runner
 package Test::Mini::TestCase;
+
 use 5.006;
 use strict;
 use warnings;
@@ -10,64 +8,19 @@ use Test::Mini;
 use Exception::Class;
 use Test::Mini::Assertions;
 
-# Constructor.
-#
-# @private
-# @param [Hash] %args Initial state for the new instance.
-# @option %args name The specific test this instance should run.
 sub new {
     my ($class, %args) = @_;
     return bless { %args, passed => 0 }, $class;
 }
 
-# Test setup behavior, automatically invoked prior to each test.  Intended to
-# be overridden by subclasses.
-#
-# @example
-#   package TestSomething;
-#   use base 'Test::Mini::TestCase';
-#
-#   use Something;
-#
-#   sub setup { $obj = Something->new(); }
-#
-#   sub test_can_foo {
-#       assert_can($obj, 'foo');
-#   }
-#
-# @see #teardown
 sub setup {
     my ($self) = @_;
 }
 
-# Test teardown behavior, automatically invoked following each test.  Intended
-# to be overridden by subclasses.
-#
-# @example
-#   package Test;
-#   use base 'Test::Mini::TestCase';
-#
-#   sub teardown { unlink 'foo.bar' }
-#
-#   sub test_touching_files {
-#       `touch foo.bar`;
-#       assert(-f 'foo.bar');
-#   }
-#
-# @see #setup
 sub teardown {
     my ($self) = @_;
 }
 
-# Runs the test specified at construction time.  This method is responsible
-# for invoking the setup and teardown advice for the method, in addition to
-# ensuring that any fatal errors encountered by the program are suitably
-# handled.  Appropriate diagnostic information should be sent to the supplied
-# +$runner+.
-#
-# @private
-# @param [Test::Mini::Runner] $runner
-# @return The number of assertions called by this test.
 sub run {
     my ($self, $runner) = @_;
     my $e;
@@ -129,3 +82,110 @@ sub run {
 }
 
 1;
+
+__END__
+
+=head1 NAME
+
+Test::Mini::TestCase - base class for Test::Mini test cases
+
+=head1 SYNOPSIS
+
+ package TestSomething;
+ use parent 'Test::Mini::TestCase';
+ use Something;
+
+ sub setup        { ... }
+ sub test_can_foo { ... }
+ sub teardown     { ... }
+
+=head1 DESCRIPTION
+
+This module should usually be the base class for any L<Test::Mini>
+test cases that you write.
+
+Any method whose name begins with C<test_> will be automatically run.
+If you've defined a C<setup> method, that will be called before each test,
+and if you've defined a C<teardown> method,
+that will be called after each test.
+
+
+=head1 CLASS METHODS
+
+=head2 new(%args)
+
+The one valid key you can pass is B<name>,
+which gives the name of a specific test to run.
+
+
+=head1 INSTANCE METHODS
+
+
+=head2 setup()
+
+Performs any initialisation required for the test,
+run once before each test. Intended to be overridden
+by subclasses.
+
+   package TestSomething;
+   use parent 'Test::Mini::TestCase';
+
+   use Something;
+
+   sub setup { $obj = Something->new(); }
+
+   sub test_can_foo {
+       assert_can($obj, 'foo');
+   }
+
+
+=head2 teardown()
+
+Test teardown behavior, automatically invoked following each test.
+Intended to be overridden by subclasses.
+
+ package Test;
+ use parent 'Test::Mini::TestCase';
+
+ sub teardown { unlink 'foo.bar' }
+
+ sub test_touching_files {
+     `touch foo.bar`;
+     assert(-f 'foo.bar');
+ }
+
+
+=head2 run($runner)
+
+Runs the test specified at construction time.
+This method is responsible for invoking the setup and teardown advice
+for the method,
+in addition to ensuring that any fatal errors encountered by the program
+are suitably handled.
+Appropriate diagnostic information should be sent to the supplied C<$runner>.
+
+Returns the number of assertions called by this test.
+
+Most of the time you won't need to override this method.
+
+
+=head1 SEE ALSO
+
+L<Test::Mini>
+
+=head1 REPOSITORY
+
+L<https://github.com/pvande/Test-Mini>
+
+=head1 AUTHOR
+
+Pieter van de Bruggen E<lt>pvande@cpan.orgE<gt>
+
+=head1 COPYRIGHT AND LICENSE
+
+This software is copyright (c) 2010 by
+Pieter van de Bruggen E<lt>pvande@cpan.orgE<gt>
+
+This is free software; you can redistribute it and/or modify it under
+the same terms as the Perl 5 programming language system itself.
+

--- a/t/Test/Mini/Assertions.t
+++ b/t/Test/Mini/Assertions.t
@@ -8,7 +8,7 @@ BEGIN {
     };
 }
 
-use base 'Test::Mini::TestCase';
+use parent 'Test::Mini::TestCase';
 use strict;
 use warnings;
 
@@ -38,7 +38,7 @@ use Test::Mini::Assertions;
 
 {
     package Mock::Bag;
-    use base 'Mock::Collection';
+    use parent -norequire, 'Mock::Collection';
 }
 
 sub assert_passes (&;$) {

--- a/t/Test/Mini/Logger.t
+++ b/t/Test/Mini/Logger.t
@@ -1,5 +1,5 @@
 package t::Test::Mini::Logger;
-use base 'Test::Mini::TestCase';
+use parent 'Test::Mini::TestCase';
 use strict;
 use warnings;
 

--- a/t/Test/Mini/Logger/TAP.t
+++ b/t/Test/Mini/Logger/TAP.t
@@ -1,5 +1,5 @@
 package t::Test::Mini::Logger::TAP;
-use base 'Test::Mini::TestCase';
+use parent 'Test::Mini::TestCase';
 use strict;
 use warnings;
 


### PR DESCRIPTION
Hi,

There are a number of changes in this PR:
- Simplified `Makefile.PL`, in the process specifying some things that weren't there before
- Changed doc to pod, and added LICENSE and other expected sections
- Specified min perl version as 5.006, in the code and in the dist metadata

This should make the distribution "CPANTS clean".

I've just done a developer release, given there are a lot of changes here. If that looks clear in a week or so, I'll update the PR to be a non-developer release, and ping you to see if you're happy to merge and release.

Cheers,
Neil
